### PR TITLE
Fix calc_sumforces return type

### DIFF
--- a/MD.cpp
+++ b/MD.cpp
@@ -262,9 +262,9 @@ void MD::update_neighbors(){
 
 }
 
-// Calculates the forces between every pair of molecules withing r_c of each other
+// Calculates the forces between every pair of molecules within r_c of each other
 // Puts the sum of fx, fy, t into the Force (m_f) of each molecule.
-double MD::calc_sumforces(){
+void MD::calc_sumforces(){
 	int m, n;
 	Water* wp;
 	Water* np;

--- a/MD.h
+++ b/MD.h
@@ -28,7 +28,7 @@ class MD{
 		void init_pos_vel();
 		void single_timestep();
 		void update_neighbors();
-		double calc_sumforces();
+                void calc_sumforces();
 		double calc_PE();
 		void lj_force(Force* f1_p, Force* f2_p, Point* o1_p, Point* o2_p, Point* cm1_p, Point* cm2_p);
 		void c_force(Force* f1_p, Force* f2_p, double q1, double q2, Point* loc1_p, Point* loc2_p, Point* cm1_p, Point* cm2_p);


### PR DESCRIPTION
## Summary
- make `calc_sumforces` return `void`
- update declaration in `MD.h`

## Testing
- `cmake ..`
- `make`
- `./water_main` (terminated early)