### PR TITLE
Fix CMake library linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,4 @@ add_executable(water_main Main.cpp
 							MD.cpp)
 
 set(GCC_COMPILE_FLAGS "-lm")
-add_definitions($(GCC_COMPILE_FLAGS))
+target_link_libraries(water_main m)


### PR DESCRIPTION
## Summary
- replace `add_definitions($(GCC_COMPILE_FLAGS))` with `target_link_libraries(water_main m)`

## Testing
- `cmake .`
- `make`
